### PR TITLE
Organize Module2 output by scenario

### DIFF
--- a/R/m2_conc.R
+++ b/R/m2_conc.R
@@ -31,7 +31,9 @@ m2_get_conc_pm25<-function(db_path, query_path, db_name, prj_name, scen_name, qu
 
   # Create the directories if they do not exist:
   if (!dir.exists("output")) dir.create("output")
-  if (!dir.exists("output/m2")) dir.create("output/m2")
+  if (!dir.exists(file.path("output", "m2"))) dir.create(file.path("output", "m2"))
+  out_dir <- file.path("output", "m2", scen_name)
+  if (!dir.exists(out_dir)) dir.create(out_dir)
   if (!dir.exists("output/maps")) dir.create("output/maps")
   if (!dir.exists("output/maps/m2")) dir.create("output/maps/m2")
   if (!dir.exists("output/maps/m2/maps_pm2.5")) dir.create("output/maps/m2/maps_pm2.5")
@@ -344,7 +346,7 @@ m2_get_conc_pm25<-function(db_path, query_path, db_name, prj_name, scen_name, qu
   pm25.write<-function(df){
     df<-as.data.frame(df)
     colnames(df)<-c("region","year","units","NAT","PRIM","SEC")
-    write.csv(df,paste0("output/","m2/","NAT_PRIM_SEC_PM2.5_",scen_name,"_",unique(df$year),".csv"),row.names = F)
+    write.csv(df, file.path(out_dir, paste0("NAT_PRIM_SEC_PM2.5_", scen_name, "_", unique(df$year), ".csv")), row.names = F)
   }
 
   if(saveOutput==T){
@@ -365,7 +367,7 @@ m2_get_conc_pm25<-function(db_path, query_path, db_name, prj_name, scen_name, qu
   pm25.agg.write<-function(df){
     df<-as.data.frame(df)
     colnames(df)<-c("region","year","units","value")
-    write.csv(df,paste0("output/","m2/","PM2.5_",scen_name,"_",unique(df$year),".csv"),row.names = F)
+    write.csv(df, file.path(out_dir, paste0("PM2.5_", scen_name, "_", unique(df$year), ".csv")), row.names = F)
   }
 
   if(saveOutput==T){
@@ -443,7 +445,9 @@ m2_get_conc_o3<-function(db_path, query_path, db_name, prj_name, scen_name, quer
 
   # Create the directories if they do not exist:
   if (!dir.exists("output")) dir.create("output")
-  if (!dir.exists("output/m2")) dir.create("output/m2")
+  if (!dir.exists(file.path("output", "m2"))) dir.create(file.path("output", "m2"))
+  out_dir <- file.path("output", "m2", scen_name)
+  if (!dir.exists(out_dir)) dir.create(out_dir)
   if (!dir.exists("output/maps")) dir.create("output/maps")
   if (!dir.exists("output/maps/m2")) dir.create("output/maps/m2")
   if (!dir.exists("output/maps/m2/maps_o3")) dir.create("output/maps/m2/maps_o3")
@@ -617,7 +621,7 @@ m2_get_conc_o3<-function(db_path, query_path, db_name, prj_name, scen_name, quer
   o3.write<-function(df){
     df<-as.data.frame(df) %>% dplyr::select(-pollutant)
     colnames(df)<-c("region","year","units","value")
-    write.csv(df,paste0("output/","m2/","O3_",scen_name,"_",unique(df$year),".csv"),row.names = F)
+    write.csv(df, file.path(out_dir, paste0("O3_", scen_name, "_", unique(df$year), ".csv")), row.names = F)
   }
 
 
@@ -696,7 +700,9 @@ m2_get_conc_m6m<-function(db_path, query_path, db_name, prj_name, scen_name, que
 
   # Create the directories if they do not exist:
   if (!dir.exists("output")) dir.create("output")
-  if (!dir.exists("output/m2")) dir.create("output/m2")
+  if (!dir.exists(file.path("output", "m2"))) dir.create(file.path("output", "m2"))
+  out_dir <- file.path("output", "m2", scen_name)
+  if (!dir.exists(out_dir)) dir.create(out_dir)
   if (!dir.exists("output/maps")) dir.create("output/maps")
   if (!dir.exists("output/maps/m2")) dir.create("output/maps/m2")
   if (!dir.exists("output/maps/m2/maps_m6m")) dir.create("output/maps/m2/maps_m6m")
@@ -901,7 +907,7 @@ m2_get_conc_m6m<-function(db_path, query_path, db_name, prj_name, scen_name, que
   m6m.write<-function(df){
     df<-as.data.frame(df) %>% dplyr::select(-pollutant)
     colnames(df)<-c("region","year","units","value")
-    write.csv(df,paste0("output/","m2/","M6M_",scen_name,"_",unique(df$year),".csv"),row.names = F)
+    write.csv(df, file.path(out_dir, paste0("M6M_", scen_name, "_", unique(df$year), ".csv")), row.names = F)
   }
 
 
@@ -980,7 +986,9 @@ m2_get_conc_aot40<-function(db_path, query_path, db_name, prj_name, scen_name, q
 
   # Create the directories if they do not exist:
   if (!dir.exists("output")) dir.create("output")
-  if (!dir.exists("output/m2")) dir.create("output/m2")
+  if (!dir.exists(file.path("output", "m2"))) dir.create(file.path("output", "m2"))
+  out_dir <- file.path("output", "m2", scen_name)
+  if (!dir.exists(out_dir)) dir.create(out_dir)
   if (!dir.exists("output/maps")) dir.create("output/maps")
   if (!dir.exists("output/maps/m2")) dir.create("output/maps/m2")
   if (!dir.exists("output/maps/m2/maps_aot40")) dir.create("output/maps/m2/maps_aot40")
@@ -1339,7 +1347,7 @@ m2_get_conc_aot40<-function(db_path, query_path, db_name, prj_name, scen_name, q
 
   aot_write<-function(df){
     df<-as.data.frame(df) %>% tidyr::spread(pollutant, value)
-    write.csv(df,paste0("output/","m2/","AOT40_",scen_name,"_",unique(df$year),".csv"),row.names = F)
+    write.csv(df, file.path(out_dir, paste0("AOT40_", scen_name, "_", unique(df$year), ".csv")), row.names = F)
   }
 
     if(saveOutput == T){
@@ -1430,7 +1438,9 @@ m2_get_conc_mi<-function(db_path, query_path, db_name, prj_name, scen_name, quer
 
   # Create the directories if they do not exist:
   if (!dir.exists("output")) dir.create("output")
-  if (!dir.exists("output/m2")) dir.create("output/m2")
+  if (!dir.exists(file.path("output", "m2"))) dir.create(file.path("output", "m2"))
+  out_dir <- file.path("output", "m2", scen_name)
+  if (!dir.exists(out_dir)) dir.create(out_dir)
   if (!dir.exists("output/maps")) dir.create("output/maps")
   if (!dir.exists("output/maps/m2")) dir.create("output/maps/m2")
   if (!dir.exists("output/maps/m2/maps_Mi")) dir.create("output/maps/m2/maps_Mi")
@@ -1786,7 +1796,7 @@ m2_get_conc_mi<-function(db_path, query_path, db_name, prj_name, scen_name, quer
 
   mi_write<-function(df){
     df<-as.data.frame(df) %>% tidyr::spread(pollutant, value)
-    write.csv(df,paste0("output/","m2/","Mi_",scen_name,"_",unique(df$year),".csv"),row.names = F)
+    write.csv(df, file.path(out_dir, paste0("Mi_", scen_name, "_", unique(df$year), ".csv")), row.names = F)
   }
 
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ pm25 <- m2_get_conc_pm25(
 CSV files must follow the naming pattern `<SCENARIO>_<YEAR>.csv` and reside in the directory given by `emissions_dir`.
 
 Module 3 and 4 functions can reuse concentration outputs written by Module 2.
-Provide the folder path via the `conc_dir` parameter (or pass loaded data with
-`conc_data`) when calling functions such as `m3_get_mort_pm25()` or
-`m4_get_ryl_aot40()`.
+Files are saved under `output/m2/<SCENARIO>` for each run. Provide that folder
+path via the `conc_dir` parameter (or pass loaded data with `conc_data`) when
+calling functions such as `m3_get_mort_pm25()` or `m4_get_ryl_aot40()`.
 
 
 In addition, the package includes some default input files (.Rda), that are read by the different functions. These can be changed by the user. Some of these constants include:

--- a/tests/testthat/test-rfasst_writeCSV.R
+++ b/tests/testthat/test-rfasst_writeCSV.R
@@ -51,7 +51,7 @@ test_that("module 2 writes csv file for PM2.5 concentration", {
   selected_year<-max(a$year)
   scen_name = "Reference"
 
-  existing_csv_pm25_conc<-read.csv(paste0(outdir,"/m2/","PM2.5_",scen_name,"_",selected_year,".csv"))
+  existing_csv_pm25_conc<-read.csv(file.path(outdir, "m2", scen_name, paste0("PM2.5_", scen_name, "_", selected_year, ".csv")))
 
   expect_s3_class(existing_csv_pm25_conc, "data.frame")
 
@@ -77,7 +77,7 @@ test_that("module 2 writes csv file for O3 concentration", {
   selected_year<-max(a$year)
   scen_name = "Reference"
 
-  existing_csv_o3_conc<-read.csv(paste0(outdir,"/m2/","O3_",scen_name,"_",selected_year,".csv"))
+  existing_csv_o3_conc<-read.csv(file.path(outdir, "m2", scen_name, paste0("O3_", scen_name, "_", selected_year, ".csv")))
 
   expect_s3_class(existing_csv_o3_conc, "data.frame")
 
@@ -103,7 +103,7 @@ test_that("module 2 writes csv file for O3-M6M concentration", {
   selected_year<-max(a$year)
   scen_name = "Reference"
 
-  existing_csv_m6m_conc<-read.csv(paste0(outdir,"/m2/","M6M_",scen_name,"_",selected_year,".csv"))
+  existing_csv_m6m_conc<-read.csv(file.path(outdir, "m2", scen_name, paste0("M6M_", scen_name, "_", selected_year, ".csv")))
 
   expect_s3_class(existing_csv_m6m_conc, "data.frame")
 
@@ -129,7 +129,7 @@ test_that("module 2 writes csv file for O3-AOT40 concentration", {
   selected_year<-max(a$year)
   scen_name = "Reference"
 
-  existing_csv_aot40_conc<-read.csv(paste0(outdir,"/m2/","AOT40_",scen_name,"_",selected_year,".csv"))
+  existing_csv_aot40_conc<-read.csv(file.path(outdir, "m2", scen_name, paste0("AOT40_", scen_name, "_", selected_year, ".csv")))
 
   expect_s3_class(existing_csv_aot40_conc, "data.frame")
 
@@ -155,7 +155,7 @@ test_that("module 2 writes csv file for O3-Mi concentration", {
   selected_year<-max(a$year)
   scen_name = "Reference"
 
-  existing_csv_mi_conc<-read.csv(paste0(outdir,"/m2/","Mi_",scen_name,"_",selected_year,".csv"))
+  existing_csv_mi_conc<-read.csv(file.path(outdir, "m2", scen_name, paste0("Mi_", scen_name, "_", selected_year, ".csv")))
 
   expect_s3_class(existing_csv_mi_conc, "data.frame")
 

--- a/vignettes/Module3_health.Rmd
+++ b/vignettes/Module3_health.Rmd
@@ -37,7 +37,7 @@ library(magrittr)
   # To save this data by TM5-FASST region in year 2050 as dataframes:
 
     pm25.mort.2050<-dplyr::bind_rows(m3_get_mort_pm25(db_path,query_path,db_name,prj_name,scen_name,queries,
-                                                      saveOutput=F, map=F, conc_dir="path_to/output/m2")) %>%
+                                                      saveOutput=F, map=F, conc_dir="path_to/output/m2/SCENARIO")) %>%
        dplyr::filter(year==2050)
      head(pm25.mort.2050)
 

--- a/vignettes/Module4_agriculture.Rmd
+++ b/vignettes/Module4_agriculture.Rmd
@@ -76,22 +76,22 @@ library(magrittr)
     # Relative yield losses.
       # Using AOT40 as O3 exposure indicator:
          ryl.aot40.2050<-dplyr::bind_rows(m4_get_ryl_aot40(db_path,query_path,db_name,prj_name,scen_name,queries,
-                                                           saveOutput=F, map=F, conc_dir="path_to/output/m2")) %>%
+                                                           saveOutput=F, map=F, conc_dir="path_to/output/m2/SCENARIO")) %>%
            dplyr::filter(year==2050)
                                                               
       # Using Mi as O3 exposure indicator:
          ryl.mi.2050<-dplyr::bind_rows(m4_get_ryl_mi(db_path,query_path,db_name,prj_name,scen_name,queries,
-                                                     saveOutput=F, map=F, conc_dir="path_to/output/m2")) %>%
+                                                     saveOutput=F, map=F, conc_dir="path_to/output/m2/SCENARIO")) %>%
            dplyr::filter(year==2050)
 
     # Production losses (includes losses using both AOT40 and Mi).
        prod.loss.2050<-dplyr::bind_rows(m4_get_prod_loss(db_path,query_path,db_name,prj_name,scen_name,queries,
-                                                         saveOutput=T, map=F, conc_dir="path_to/output/m2")) %>%
+                                                         saveOutput=T, map=F, conc_dir="path_to/output/m2/SCENARIO")) %>%
          dplyr::filter(year==2050)
 
     # Revenue losses (includes losses using both AOT40 and Mi).
        rev.loss.2050<-dplyr::bind_rows(m4_get_rev_loss(db_path,query_path,db_name,prj_name,scen_name,queries,
-                                                       saveOutput=T, map=F, conc_dir="path_to/output/m2")) %>%
+                                                       saveOutput=T, map=F, conc_dir="path_to/output/m2/SCENARIO")) %>%
          dplyr::filter(year==2050)
 
 


### PR DESCRIPTION
## Summary
- store Module 2 outputs inside `output/m2/<SCENARIO>` to keep results from multiple runs
- document new location in README and vignettes
- update tests for new output path

## Testing
- `Rscript -e 'print("test")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870da1ff8248333a67d71dd049d3d76