### PR TITLE
Remove breaks param from map calls

### DIFF
--- a/R/m2_conc.R
+++ b/R/m2_conc.R
@@ -388,14 +388,10 @@ m2_get_conc_pm25<-function(db_path, query_path, db_name, prj_name, scen_name, qu
       dplyr::mutate(units="ug/m3",
                     year=as.numeric(as.character(year)))
 
-    brks <- seq(floor(min(pm25.map$value)/5)*5,
-                ceiling(max(pm25.map$value)/5)*5, by = 5)
-
     rmap::map(data = pm25.map,
               shape = fasstSubset,
               folder = "output/maps/m2/maps_pm2.5",
               legendType = "pretty",
-              breaks = brks,
               background  = T,
               animate = anim)
 
@@ -642,14 +638,10 @@ m2_get_conc_o3<-function(db_path, query_path, db_name, prj_name, scen_name, quer
       dplyr::mutate(units="ppbv",
                     year=as.numeric(as.character(year)))
 
-    brks <- seq(floor(min(o3.map$value)/5)*5,
-                ceiling(max(o3.map$value)/5)*5, by = 5)
-
     rmap::map(data = o3.map,
               shape = fasstSubset,
               folder = "output/maps/m2/maps_o3",
               legendType = "pretty",
-              breaks = brks,
               background  = T,
               animate = anim)
 
@@ -928,14 +920,10 @@ m2_get_conc_m6m<-function(db_path, query_path, db_name, prj_name, scen_name, que
       dplyr::mutate(units = "ppbv",
                     year=as.numeric(as.character(year)))
 
-    brks <- seq(floor(min(m6m.map$value)/5)*5,
-                ceiling(max(m6m.map$value)/5)*5, by = 5)
-
     rmap::map(data = m6m.map,
               shape = fasstSubset,
               folder = "output/maps/m2/maps_m6m",
               legendType = "pretty",
-              breaks = brks,
               background  = T,
               animate = anim)
 
@@ -1368,9 +1356,6 @@ m2_get_conc_aot40<-function(db_path, query_path, db_name, prj_name, scen_name, q
       dplyr::mutate(units = "ppm.h",
                     year = as.numeric(as.character(year)))
 
-    brks <- seq(floor(min(aot.map$value)/5)*5,
-                ceiling(max(aot.map$value)/5)*5, by = 5)
-
     aot.map.list<-split(aot.map,aot.map$pollutant)
 
    make.map.aot40<-function(df){
@@ -1383,7 +1368,6 @@ m2_get_conc_aot40<-function(db_path, query_path, db_name, prj_name, scen_name, q
               shape = fasstSubset,
               folder =paste0("output/maps/m2/maps_aot40/maps_aot40_",unique(df$crop)),
               legendType = "pretty",
-              breaks = brks,
               background  = T,
               animate = anim)
 
@@ -1818,9 +1802,6 @@ m2_get_conc_mi<-function(db_path, query_path, db_name, prj_name, scen_name, quer
       dplyr::mutate(units = "ppbv",
                     year = as.numeric(as.character(year)))
 
-    brks <- seq(floor(min(mi.map$value)/5)*5,
-                ceiling(max(mi.map$value)/5)*5, by = 5)
-
     mi.map.list<-split(mi.map,mi.map$pollutant)
 
     make.map.mi<-function(df){
@@ -1833,7 +1814,6 @@ m2_get_conc_mi<-function(db_path, query_path, db_name, prj_name, scen_name, quer
                 shape = fasstSubset,
                 folder =paste0("output/maps/m2/maps_Mi/maps_Mi_",unique(df$crop)),
                 legendType = "pretty",
-                breaks = brks,
                 background  = T,
                 animate = anim)
 


### PR DESCRIPTION
## Summary
- simplify `m2_conc` by removing manual break calculations for maps

## Testing
- `R CMD build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687120d801808333880b89d1430207ae